### PR TITLE
Add pkg-config as system package dependency

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -30,6 +30,7 @@ libffi-dev        [platform:dpkg]
 python2.7         [platform:dpkg]
 python-apt        [platform:dpkg]
 python-dev        [platform:dpkg]
+pkg-config        [platform:dpkg]
 
 # Base requirements for RPM distros
 gcc               [platform:rpm]


### PR DESCRIPTION
Install pkg-config so as to build and install libvirt-python which is
a dependency of virtualbmc.

Fixes #1.