### PR TITLE
Add number of minor tweaks

### DIFF
--- a/playbooks/deploy-osp.yml
+++ b/playbooks/deploy-osp.yml
@@ -140,7 +140,7 @@
       shell: |
         set -o pipefail
         openstack undercloud install \
-        2>&1 | tee -a /home/stack/logs/undercloud_install.log
+        2>&1 | tee /home/stack/logs/undercloud_install.log
       become_user: stack
 
     - name: Installing Red Hat undercloud images
@@ -155,7 +155,7 @@
       shell: |
         set -o pipefail
         /home/stack/scripts/undercloud-post-install.sh \
-        2>&1 | tee -a /home/stack/logs/undercloud_post_install_log
+        2>&1 | tee /home/stack/logs/undercloud_post_install_log
       become: true
       become_user: stack
 
@@ -185,5 +185,5 @@
         -e /home/stack/templates/node-info.yaml \
         -e /home/stack/templates/overcloud_images.yaml \
         --ntp-server pool.ntp.org \
-        2>&1 | tee -a /home/stack/logs/overcloud_install.log
+        2>&1 | tee /home/stack/logs/overcloud_install.log
       become_user: stack

--- a/playbooks/deploy-osp.yml
+++ b/playbooks/deploy-osp.yml
@@ -137,7 +137,10 @@
           mode: "0754"
 
     - name: Undercloud deploy - tail -f /home/stack/logs/undercloud_install.log to view progress
-      shell: "openstack undercloud install 2>&1 | tee -a /home/stack/logs/undercloud_install.log"
+      shell: |
+        set -o pipefail
+        openstack undercloud install \
+        2>&1 | tee -a /home/stack/logs/undercloud_install.log
       become_user: stack
 
     - name: Installing Red Hat undercloud images
@@ -149,7 +152,10 @@
         - rhosp-director-images-ipa
 
     - name: Create images, import inventory, attach images, tag nodes, create container registry
-      shell: "/home/stack/scripts/undercloud-post-install.sh 2>&1 | tee -a /home/stack/logs/undercloud_post_install_log"
+      shell: |
+        set -o pipefail
+        /home/stack/scripts/undercloud-post-install.sh \
+        2>&1 | tee -a /home/stack/logs/undercloud_post_install_log
       become: true
       become_user: stack
 
@@ -173,6 +179,7 @@
 
     - name: Overcloud deploy - tail -f /home/stack/logs/overcloud_install.log to view progress
       shell: |
+        set -o pipefail
         source /home/stack/stackrc
         openstack overcloud deploy --templates \
         -e /home/stack/templates/node-info.yaml \

--- a/playbooks/inventory/hosts
+++ b/playbooks/inventory/hosts
@@ -16,10 +16,6 @@ ceph2            ansible_host=10.0.236.131
 ceph3            ansible_host=10.0.236.132
 compute1         ansible_host=10.0.236.120
 compute2         ansible_host=10.0.236.121
-loadbalancer1    ansible_host=10.0.236.150
-swift1           ansible_host=10.0.236.140
-swift2           ansible_host=10.0.236.141
-swift3           ansible_host=10.0.236.142
 
 ################################# MNAIO HOSTS #################################
 
@@ -58,10 +54,6 @@ director
 controller1
 controller2
 controller3
-loadbalancer1
-swift1
-swift2
-swift3
 
 ################################## OSA HOSTS ##################################
 
@@ -69,6 +61,3 @@ swift3
 #  originate from.
 [deploy_hosts]
 director
-
-[loadbalancer_hosts]
-loadbalancer1

--- a/playbooks/osp/13/undercloud/instackenv.json
+++ b/playbooks/osp/13/undercloud/instackenv.json
@@ -13,7 +13,8 @@
             "pm_user":"root",
             "pm_password":"secrete",
             "pm_addr":"192.168.24.254",
-            "pm_port": "624"
+            "pm_port": "624",
+            "capabilities": "profile:control,boot_option:local"
         },
         {
             "mac":[
@@ -28,7 +29,8 @@
             "pm_user":"root",
             "pm_password":"secrete",
             "pm_addr":"192.168.24.254",
-            "pm_port": "625"
+            "pm_port": "625",
+            "capabilities": "profile:control,boot_option:local"
         },
         {
             "mac":[
@@ -43,7 +45,8 @@
             "pm_user":"root",
             "pm_password":"secrete",
             "pm_addr":"192.168.24.254",
-            "pm_port": "626"
+            "pm_port": "626",
+            "capabilities": "profile:control,boot_option:local"
         },
         {
             "mac":[
@@ -58,7 +61,8 @@
             "pm_user":"root",
             "pm_password":"secrete",
             "pm_addr":"192.168.24.254",
-            "pm_port": "627"
+            "pm_port": "627",
+            "capabilities": "profile:compute,boot_option:local"
         },
         {
             "mac":[
@@ -73,7 +77,8 @@
             "pm_user":"root",
             "pm_password":"secrete",
             "pm_addr":"192.168.24.254",
-            "pm_port": "628"
+            "pm_port": "628",
+            "capabilities": "profile:compute,boot_option:local"
         },
         {
             "mac":[
@@ -88,7 +93,8 @@
             "pm_user":"root",
             "pm_password":"secrete",
             "pm_addr":"192.168.24.254",
-            "pm_port": "629"
+            "pm_port": "629",
+            "capabilities": "profile:ceph-storage,boot_option:local"
         },
         {
             "mac":[
@@ -103,7 +109,8 @@
             "pm_user":"root",
             "pm_password":"secrete",
             "pm_addr":"192.168.24.254",
-            "pm_port": "630"
+            "pm_port": "630",
+            "capabilities": "profile:ceph-storage,boot_option:local"
         },
         {
             "mac":[
@@ -118,7 +125,8 @@
             "pm_user":"root",
             "pm_password":"secrete",
             "pm_addr":"192.168.24.254",
-            "pm_port": "631"
+            "pm_port": "631",
+            "capabilities": "profile:ceph-storage,boot_option:local"
         }
     ]
 }

--- a/playbooks/osp/13/undercloud/undercloud.conf.j2
+++ b/playbooks/osp/13/undercloud/undercloud.conf.j2
@@ -168,7 +168,7 @@ local_interface = eth0
 #undercloud_update_packages = true
 
 # Whether to install Tempest in the Undercloud. (boolean value)
-#enable_tempest = true
+enable_tempest = true
 
 # Whether to install Telemetry services (ceilometer, gnocchi, aodh,
 # panko ) in the Undercloud. (boolean value)

--- a/playbooks/osp/13/undercloud/undercloud.conf.j2
+++ b/playbooks/osp/13/undercloud/undercloud.conf.j2
@@ -179,7 +179,12 @@ enable_ui = true
 
 # Whether to install requirements to run the TripleO validations.
 # (boolean value)
-#enable_validations = true
+# NOTE(coreywright): Enable validation of undercloud/director node and
+# undercloud.conf immediately before undercloud deployment.  See
+# https://github.com/openstack/python-tripleoclient/blob/stable/queens/tripleoclient/v1/undercloud_config.py#L577-L578
+# and
+# https://github.com/openstack/python-tripleoclient/blob/stable/queens/tripleoclient/v1/undercloud_preflight.py#L372-L389
+enable_validations = true
 
 # Whether to install the Volume service. It is not currently used in
 # the undercloud. (boolean value)

--- a/playbooks/osp/13/undercloud/undercloud.conf.j2
+++ b/playbooks/osp/13/undercloud/undercloud.conf.j2
@@ -161,7 +161,7 @@ local_interface = eth0
 
 # Whether to enable the debug log level for Undercloud OpenStack
 # services. (boolean value)
-#undercloud_debug = true
+undercloud_debug = true
 
 # Whether to update packages during the Undercloud install. (boolean
 # value)

--- a/playbooks/osp/13/undercloud/undercloud_post_install_osp.sh.j2
+++ b/playbooks/osp/13/undercloud/undercloud_post_install_osp.sh.j2
@@ -26,19 +26,6 @@ openstack overcloud node import /home/stack/instackenv.json
 # set dns servers
 openstack subnet set --dns-nameserver 8.8.8.8 --dns-nameserver 8.8.4.4 ctlplane-subnet
 
-# Tagging nodes roles and names, we require to know the servers IDs first
-openstack baremetal node list | grep controller1 | awk '{print $2}' | xargs -I '{}' openstack baremetal node set --property capabilities='profile:control,boot_option:local' '{}'
-openstack baremetal node list | grep controller2 | awk '{print $2}' | xargs -I '{}' openstack baremetal node set --property capabilities='profile:control,boot_option:local' '{}'
-openstack baremetal node list | grep controller3 | awk '{print $2}' | xargs -I '{}' openstack baremetal node set --property capabilities='profile:control,boot_option:local' '{}'
-openstack baremetal node list | grep compute1 | awk '{print $2}' | xargs -I '{}' openstack baremetal node set --property capabilities='profile:compute,boot_option:local' '{}'
-openstack baremetal node list | grep compute2 | awk '{print $2}' | xargs -I '{}' openstack baremetal node set --property capabilities='profile:compute,boot_option:local' '{}'
-openstack baremetal node list | grep ceph1 | awk '{print $2}' | xargs -I '{}' openstack baremetal node set --property capabilities='profile:ceph-storage,boot_option:local' '{}'
-openstack baremetal node list | grep ceph2 | awk '{print $2}' | xargs -I '{}' openstack baremetal node set --property capabilities='profile:ceph-storage,boot_option:local' '{}'
-openstack baremetal node list | grep ceph3 | awk '{print $2}' | xargs -I '{}' openstack baremetal node set --property capabilities='profile:ceph-storage,boot_option:local' '{}'
-
-#openstack baremetal node list | grep swift1 | awk '{print $2}' | xargs -I '{}' openstack baremetal node set --property capabilities='profile:swift-storage,boot_option:local' '{}'
-#openstack baremetal node list | grep swift2 | awk '{print $2}' | xargs -I '{}' openstack baremetal node set --property capabilities='profile:swift-storage,boot_option:local' '{}'
-
 openstack overcloud container image prepare \
   -e /usr/share/openstack-tripleo-heat-templates/environments/ceph-ansible/ceph-ansible.yaml \
   -e /usr/share/openstack-tripleo-heat-templates/environments/services-docker/sahara.yaml \


### PR DESCRIPTION
* Enable tempest installation
* Enable undercloud pre-deployment validation
* Enable undercloud debug logging
* Assign profiles to nodes in instackenv.json, not through scripting
* Set pipefail when piping with Ansible shell module
* Don't append onto existing log files
* Clean-up inventory
