### PR TITLE
Increase RAM for controllers

### DIFF
--- a/playbooks/host_vars/controller1.yml
+++ b/playbooks/host_vars/controller1.yml
@@ -18,7 +18,7 @@ ansible_os_family: "{{ images[default_vm_image]['image_type'] }}"
 server_hostname: 'controller1'
 server_domain_name: 'openstack.local'
 server_vm: true
-server_vm_ram: '{{ controller_vm_server_ram | default(8192) }}'
+server_vm_ram: '{{ controller_vm_server_ram | default(16384) }}'
 server_vm_vcpus: '{{ controller_vm_server_vcpus | default(4) }}'
 server_vm_primary_network: 'dhcp'
 server_image: "{{ default_vm_image }}"

--- a/playbooks/host_vars/controller2.yml
+++ b/playbooks/host_vars/controller2.yml
@@ -18,7 +18,7 @@ ansible_os_family: "{{ images[default_vm_image]['image_type'] }}"
 server_hostname: 'controller2'
 server_domain_name: 'openstack.local'
 server_vm: true
-server_vm_ram: '{{ controller_vm_server_ram | default(8192) }}'
+server_vm_ram: '{{ controller_vm_server_ram | default(16384) }}'
 server_vm_vcpus: '{{ controller_vm_server_vcpus | default(4) }}'
 server_vm_primary_network: 'dhcp'
 server_image: "{{ default_vm_image }}"

--- a/playbooks/host_vars/controller3.yml
+++ b/playbooks/host_vars/controller3.yml
@@ -18,7 +18,7 @@ ansible_os_family: "{{ images[default_vm_image]['image_type'] }}"
 server_hostname: 'controller3'
 server_domain_name: 'openstack.local'
 server_vm: true
-server_vm_ram: '{{ controller_vm_server_ram | default(8192) }}'
+server_vm_ram: '{{ controller_vm_server_ram | default(16384) }}'
 server_vm_vcpus: '{{ controller_vm_server_vcpus | default(4) }}'
 server_vm_primary_network: 'dhcp'
 server_image: "{{ default_vm_image }}"


### PR DESCRIPTION
Minimum recommended amount is 32GB per controller,
so bumping to 16GB per controller to give them some
more breathing room and still be able to run within
a 128GB server.