### PR TITLE
Fix `osa` reference, changing it to `osp`

### DIFF
--- a/playbooks/deploy-osp.yml
+++ b/playbooks/deploy-osp.yml
@@ -20,7 +20,7 @@
   remote_user: stack
   become: yes
   tags:
-    - deploy-osa
+    - deploy-osp
   tasks:
     - name: Gather variables for each operating system
       include_vars: "{{ item }}"


### PR DESCRIPTION
Correct the oversight of the `deploy-osa` Ansible tag remaining
unchanged when porting openstack-ansible-ops' multi-node-aio
playbooks, which are associated with the OpenStack-Ansible project
which itself is abbreviated "OSA", to osp-mnaio, where "OSP" stands
for Red Hat's "OpenStack Platform" product.