### PR TITLE
Disable rgw until upstream fixes roll in

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,6 +52,7 @@ ansible-playbook -vv \
                  -e redhat_osp_version=${REDHAT_OSP_VERSION:-"13"} \
                  -e redhat_overcloud_register=${REDHAT_OVERCLOUD_REGISTER:-'false'} \
                  -e enable_ceph_storage=${ENABLE_CEPH_STORAGE:-"true"} \
+                 -e enable_ceph_rgw=${ENABLE_CEPH_RGW:-"false"} \
                  -e ceph_osds_size=${ceph_osds_size:-"20480"} \
                  -e ceph_journal_size=${CEPH_JOURNAL_SIZE:-"5120"} \
                  -e ipxe_path_url=${IPXE_PATH_URL:-""} ${MNAIO_ANSIBLE_PARAMETERS} \

--- a/playbooks/osp/13/overcloud/overcloud-deploy.sh.j2
+++ b/playbooks/osp/13/overcloud/overcloud-deploy.sh.j2
@@ -15,7 +15,9 @@ openstack overcloud deploy --templates \
 {% endif %}
 {% if enable_ceph_storage | bool %}
    -e /usr/share/openstack-tripleo-heat-templates/environments/ceph-ansible/ceph-ansible.yaml \
+{% if enable_ceph_rgw | bool %}
    -e /usr/share/openstack-tripleo-heat-templates/environments/ceph-ansible/ceph-rgw.yaml \
+{% endif %}
    -e /home/stack/templates/ceph-custom-config.yaml \
 {% endif %}
    --ntp-server pool.ntp.org \


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1622505
https://bugzilla.redhat.com/show_bug.cgi?id=1618678

"msg": "'dict object' has no attribute 'rgw_hostname'" during TASK
[ceph-config : generate ceph.conf configuration file]