### PR TITLE
Keep working directory as /home/stack for deploy

### DIFF
--- a/playbooks/deploy-osp.yml
+++ b/playbooks/deploy-osp.yml
@@ -197,7 +197,7 @@
       become_user: stack
 
     - name: Overcloud deploy - tail -f /home/stack/logs/overcloud_install.log to view progress
-      shell: bash overcloud-deploy.sh
+      shell: bash scripts/overcloud-deploy.sh
       args:
-        chdir: /home/stack/scripts
+        chdir: /home/stack
       become_user: stack


### PR DESCRIPTION
It seems that if the script is ran from the previous
working directory, the overcloudrc is dumped in scripts
rather than /home/stack during overcloud_deploy.

This should hopefully correct that.