### PR TITLE
ASC-801 Add system test execution to gating

### DIFF
--- a/gating/periodic/run
+++ b/gating/periodic/run
@@ -39,6 +39,8 @@ elif [ "${OSP_JOB_ACTION}" = "deploy-full-tests" ]; then
     # null, explicitly specify all tests so the default test regex in build.sh
     # doesn't get used.
     export TEMPEST_TESTS='--regex ^.*$ --blacklist-file /home/stack/tempest-blacklist.txt'
+elif [ "${OSP_JOB_ACTION}" = "deploy-system-tests" ]; then
+    export TEMPEST_TESTS=''
 else
     echo "ERROR: unhandled OSP_JOB_ACTION value: \"${OSP_JOB_ACTION}\""
     exit 1
@@ -48,3 +50,7 @@ fi
 pushd /opt/osp-mnaio
   ./build.sh
 popd
+
+if [ "${OSP_JOB_ACTION}" = "deploy-system-tests" ]; then
+    bash -c "$(readlink -f $(dirname ${0})/run_system_tests.sh)"
+fi

--- a/gating/periodic/run_system_tests.sh
+++ b/gating/periodic/run_system_tests.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+## Deploy virtualenv for testing environment molecule/ansible-playbook/infratest
+
+## Shell Opts ----------------------------------------------------------------
+
+set -ex
+set -o pipefail
+
+## Variables -----------------------------------------------------------------
+
+RE_HOOK_ARTIFACT_DIR="${RE_HOOK_ARTIFACT_DIR:-/tmp/artifacts}"
+export RE_HOOK_RESULT_DIR="${RE_HOOK_RESULT_DIR:-/tmp/results}"
+SYS_WORKING_DIR=$(mktemp  -d -t system_test_workingdir.XXXXXXXX)
+export SYS_VENV_NAME="${SYS_VENV_NAME:-venv-molecule}"
+SYS_TEST_SOURCE_BASE="${SYS_TEST_SOURCE_BASE:-https://github.com/rcbops}"
+SYS_TEST_SOURCE="${SYS_TEST_SOURCE:-rpc-openstack-system-tests}"
+SYS_TEST_SOURCE_REPO="${SYS_TEST_SOURCE_BASE}/${SYS_TEST_SOURCE}"
+SYS_TEST_BRANCH="osp${REDHAT_OSP_VERSION}"
+
+# Switch system test branch to `dev` on the experimental-asc job.
+# This job is specifically for running system tests under development.
+if [[ ${RE_JOB_NAME} == experimental-asc* ]] ; then
+    SYS_TEST_BRANCH=dev
+fi
+
+## Main ----------------------------------------------------------------------
+
+# 1. Clone test repository into working directory.
+pushd "${SYS_WORKING_DIR}"
+git clone "${SYS_TEST_SOURCE_REPO}"
+cd "${SYS_TEST_SOURCE}"
+
+# Checkout defined branch
+git checkout "${SYS_TEST_BRANCH}"
+echo "${SYS_TEST_SOURCE} at SHA $(git rev-parse HEAD)"
+
+# Gather submodules
+git submodule init
+git submodule update --recursive
+
+# fail softly if the tests or artifact gathering fails
+set +e
+
+# 2. Execute script from repository
+./execute_tests.sh
+[[ $? -ne 0 ]] && RC=$?  # record non-zero exit code
+
+# 3. Collect results from script, if they exist
+mkdir -p "${RE_HOOK_RESULT_DIR}" || true  # ensure that result directory exists
+if [[ -e test_results.tar ]]; then
+  tar -xf test_results.tar -C "${RE_HOOK_RESULT_DIR}"
+fi
+
+# 4. Collect logs from script, if they exist
+mkdir -p "${RE_HOOK_ARTIFACT_DIR}" || true  # ensure that artifact directory exists
+if [[ -e test_results.tar ]]; then
+  cp test_results.tar "${RE_HOOK_ARTIFACT_DIR}/molecule_test_results.tar"
+fi
+popd
+
+# if exit code is recorded, use it, otherwise let it exit naturally
+[[ -z ${RC+x} ]] && exit ${RC}


### PR DESCRIPTION
This commit adds a `run_system_tests.sh` script to gating in order to
run tests for OSP associated with the
https://github.com/rcbops/rpc-openstack-system-tests/tree/osp13
repository.  This script is set to be triggered by the `run` command
when the `OSP_JOB_ACTION` is set to `deploy-system-tests`.