### PR TITLE
ASC-1263: Disable OVN by default

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -63,6 +63,7 @@ ansible-playbook -vv \
                  -e enable_sahara=${ENABLE_SAHARA:-"true"} \
                  -e enable_manila=${ENABLE_MANILA:-"true"} \
                  -e enable_barbican=${ENABLE_BARBICAN:-"true"} \
+                 -e enable_ovn=${ENABLE_OVN:-"false"} \
                  -e ipxe_path_url=${IPXE_PATH_URL:-""} ${MNAIO_ANSIBLE_PARAMETERS} \
                  --force-handlers \
                  --flush-cache \

--- a/playbooks/osp/13/overcloud/overcloud-deploy.sh.j2
+++ b/playbooks/osp/13/overcloud/overcloud-deploy.sh.j2
@@ -35,7 +35,9 @@ openstack overcloud deploy --templates \
 {% else %}
    -e /home/stack/templates/overcloud_images.yaml \
 {% endif %}
+{% if enable_ovn | bool %}
    -e /usr/share/openstack-tripleo-heat-templates/environments/services-docker/neutron-ovn-ha.yaml \
+{% endif %}
    --ntp-server pool.ntp.org \
    2>&1 | tee /home/stack/logs/overcloud_install.log
 

--- a/playbooks/osp/13/undercloud/undercloud_post_install_osp.sh.j2
+++ b/playbooks/osp/13/undercloud/undercloud_post_install_osp.sh.j2
@@ -53,7 +53,9 @@ openstack overcloud container image prepare \
   --output-images-file /home/stack/local_registry_images.yaml \
   --output-env-file /home/stack/templates/overcloud_images.yaml \
 {% endif %}
+{% if enable_ovn | bool %}
   -e /usr/share/openstack-tripleo-heat-templates/environments/services-docker/neutron-ovn-ha.yaml \
+{% endif %}
   --namespace=registry.access.redhat.com/rhosp13 \
   --push-destination=192.168.24.1:8787 \
   --prefix=openstack- \


### PR DESCRIPTION
Neither Red Hat nor RPC-R enables OVN in OSP 13 by default, so follow
suite.

While there are benefits to OVN (eg intermediate Linux bridge is not
necessary to implement security groups), there are detriments,
primarily the lack of familiarity and documentation (or at least lack
of emphasis on OVN, and instead ML2/ovs, in documentation), so disable
OVN by default, but allow it to be enabled with an environment
variable.