### PR TITLE
ASC-1031 Run system tests based on job scenario

### DIFF
--- a/gating/periodic/run_system_tests.sh
+++ b/gating/periodic/run_system_tests.sh
@@ -17,6 +17,8 @@ SYS_TEST_SOURCE_BASE="${SYS_TEST_SOURCE_BASE:-https://github.com/rcbops}"
 SYS_TEST_SOURCE="${SYS_TEST_SOURCE:-rpc-openstack-system-tests}"
 SYS_TEST_SOURCE_REPO="${SYS_TEST_SOURCE_BASE}/${SYS_TEST_SOURCE}"
 SYS_TEST_BRANCH="osp${REDHAT_OSP_VERSION}"
+SYS_JOB_SCENARIO=$(echo "${RE_JOB_SCENARIO}" | awk -F'_' \{'print $NF'\} |
+                   { read -r x; echo "${x##*[0-9]}";  })
 
 # Switch system test branch to `dev` on the experimental-asc job.
 # This job is specifically for running system tests under development.
@@ -43,7 +45,11 @@ git submodule update --recursive
 set +e
 
 # 2. Execute script from repository
-./execute_tests.sh
+if [[ -z $SYS_JOB_SCENARIO ]]; then
+  ./execute_tests.sh -s default
+else
+  ./execute_tests.sh -s default -s $SYS_JOB_SCENARIO
+fi
 [[ $? -ne 0 ]] && RC=$?  # record non-zero exit code
 
 # 3. Collect results from script, if they exist


### PR DESCRIPTION
This commit parses the `RE_JOB_SCENARIO` to determine additional system
tests to execute based on job context.  The testing scenario is taken
from the last segment of the `RE_JOB_SCENARIO` with any preceding
numerical prefix stripped from the segment.  For example, a value of
`3ctlr_2comp_3ceph` for the `RE_JOB_SCENARIO` will be parsed into the
value of `ceph` for the `SYS_JOB_SCENARIO` variable.  This value is then
appended to the list of system test molecule scenarios to execute for
the system-test job run.

This update allows system test for incompatible scenarios to
introspected and tested in context of the given job. For example, `ceph`
and `swift` scenarios can be run in different deployment jobs and the
undefined scenario will not be run.