### PR TITLE
Pin Ansible to 2.7.10

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -87,4 +87,4 @@ fi
 sudo python -m easy_install --upgrade pyOpenSSL
 
 # install latest OSA supported Ansible version
-sudo pip install ansible ara
+sudo pip install ansible==2.7.10 ara


### PR DESCRIPTION
It appears that 2.8 may break some filters like the one that
pulls the gateway value setting it to false instead of translating
the value.

https://github.com/rcbops/osp-mnaio/blob/master/playbooks/pxe/configs/redhat/rhel-network.sh.j2#L26

The resulting template ends up as GATEWAY=false

There may be other breakage from 2.8, so pinning to latest 2.7
for now to allow for bugs to be shaken out in the 2.8 series.